### PR TITLE
Fixed the negative timer issue, timer stops at 0

### DIFF
--- a/code/assets/script.js
+++ b/code/assets/script.js
@@ -13,13 +13,16 @@ function generateQuiz({ question, options, answer }) {
     isChoose = true;
     const opt = e.target;
     displayAnswer(opt.dataset.idx == answer);
-    setTimeout(
-      () =>
-        next >= quiz.length || Number(time.textContent) <= 0
-          ? displayScore()
-          : updateQuiz(next++),
-      1000
-    );
+
+    setTimeout(() => {
+      if (next >= quiz.length || Number(time.textContent) <= 0) {
+        clearInterval(timeId); // Clear the interval if time is 0 or negative
+        time.textContent = "0";
+        displayScore();
+      } else {
+        updateQuiz(next++);
+      }
+    }, 1000);
   };
   main.innerHTML = "";
 
@@ -179,7 +182,15 @@ function goBack() {
     generateQuiz(quiz[0]);
     time.textContent = "50";
     next = 1;
-    timeId = setInterval(() => (time.textContent -= 1), 1000);
+    timeId = setInterval(() => {
+      if (Number(time.textContent) > 0) {
+          time.textContent -= 1;
+      } else {
+          clearInterval(timeId); // Clear the interval when the timer reaches 0
+          time.textContent = "0";
+          displayScore(); // Call a function to display the user's score or end the quiz
+      }
+  }, 1000);
   });
 }
 


### PR DESCRIPTION
Fixing issue #23 
Earlier:

The timer would count down to below 0 indefinitely. The quiz would end only when both of two conditions were satisfied: 
1) An answer was submitted
2) Timer was <=0

But the quiz should end even if only the 2nd condition gets satisfied. 

Quiz continues even when time goes below 0:
![image](https://github.com/bhaavvya/Quiz/assets/94625954/4e09a8b6-f1a2-4eee-baee-6860a8691b96)

After submitting answer, quiz stops but shows negative time:
![image](https://github.com/bhaavvya/Quiz/assets/94625954/6dd0b4af-6747-41d0-bd96-7a952db997e0)


Now:

The quiz stops as soon as timer hits 0:
https://github.com/bhaavvya/Quiz/assets/94625954/371ab2b5-ab56-4020-b698-8590a06cae88

Timer shows '0' instead of negative time after quiz ends:
![image](https://github.com/bhaavvya/Quiz/assets/94625954/fd1ddfea-69cf-4314-b3b6-fb23b0c06d88)





